### PR TITLE
process `aliyun_logs_` env to support k8s pod and containers

### DIFF
--- a/docker-images/fluentd.tpl
+++ b/docker-images/fluentd.tpl
@@ -32,6 +32,7 @@ host "#{Socket.gethostname}"
 
 {{if $.source.Application}}docker_app {{ $.source.Application }} {{end}}
 {{if $.source.Service}}docker_service {{ $.source.Service }} {{end}}
+{{if $.source.POD}}k8s_pod {{ $.source.POD }} {{end}}
 {{if $.source.Container}}docker_container {{ $.source.Container }} {{end}}
 </record>
 </filter>


### PR DESCRIPTION
```
kubectl run hello-minikube --env "aliyun_logs_test=stdout" --image=gcr.io/google_containers/echoserver:1.4 --port=8080
```