### PR TITLE
Feature 增加对容器内部输出json格式日志支持，便于sls索引

### DIFF
--- a/docker-images/fluentd.tpl
+++ b/docker-images/fluentd.tpl
@@ -19,6 +19,14 @@
 time_key {{ .TimeKey}}
 </filter>
 
+{{if .JsonParserConfig}}
+<filter docker.{{ $.containerId }}.{{ .Name }}>
+@type contians_log_json_parser
+{{range $key, $value := .JsonParserConfig}}
+{{ $key }} {{ $value }}
+{{end}}
+</filter>
+{{end}}
 
 <filter docker.{{ $.containerId }}.{{ .Name }}>
 @type record_transformer

--- a/docker-images/plugins/filter_add_time.rb
+++ b/docker-images/plugins/filter_add_time.rb
@@ -14,9 +14,10 @@ class Fluent::AddTimeFilter < Fluent::Filter
   end
 
   def filter(tag, time, record)
-	if record.nil? 
-		return
-	end
+    if record.nil?
+      return
+    end
+
     record[@time_key] = Time.now.strftime '%Y-%m-%dT%H:%M:%S.%L'
     return record
   end

--- a/docker-images/plugins/filter_contians_log_json_parser.rb
+++ b/docker-images/plugins/filter_contians_log_json_parser.rb
@@ -1,0 +1,49 @@
+require 'fluent/filter'
+
+module Fluent
+  class DockerLogReserveFilter < Filter
+    Fluent::Plugin.register_filter('contians_log_json_parser', self)
+
+    # config_param works like other plugins
+    config_param :jsonkey, :string, :default => 'log'
+
+    def configure(conf)
+      super
+      # do the usual configuration here
+    end
+
+    def start
+      super
+      # This is the first method to be called when it starts running
+      # Use it to allocate resources, etc.
+    end
+
+    def shutdown
+      super
+      # This method is called when Fluentd is shutting down.
+      # Use it to free up resources, etc.
+    end
+
+    def filter(tag, time, record)
+      if record.nil?
+        return
+      end
+      if @jsonkey.nil? or !record.has_key?(@jsonkey)
+        return record
+      end
+
+      begin
+        h = JSON.parse(record[@jsonkey])
+        h.each do |k,v|
+          # adapt sls fmt
+          out = (v.is_a?(Hash)) ? ("#{v}") : (v)
+          out = (v.is_a?(Numeric)) ? ("#{v}") : (v)
+          record[k] = out
+        end
+        record.delete(@jsonkey)
+      rescue
+      end
+      return record
+    end
+  end
+end

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -67,3 +67,4 @@ There are many labels you can use to describe the log info.
 - `aliyun.logs.$name.target=target-for-log-storage`: target is used by the output plugins, instruct the plugins to store
 logs in appropriate place. For elasticsearch output, target means the log index in elasticsearch. For aliyun_sls output,
 target means the logstore in aliyun sls. The default value of target is the log name.
+- `aliyun.logs.$name.jsonkey=log`: work when `aliyun.logs.$name=stdout`. can loads json from docker container log like `{"log":"{\"foo\": \"bar\"}","stream":"stdout","time":"2017-09-15T16:28:29.253264378Z"}`.

--- a/main.go
+++ b/main.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"flag"
-	log "github.com/Sirupsen/logrus"
-	"github.com/AliyunContainerService/fluentd-pilot/pilot"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/AliyunContainerService/fluentd-pilot/pilot"
+	log "github.com/Sirupsen/logrus"
 )
 
 func main() {

--- a/pilot/fluentd_wrapper.go
+++ b/pilot/fluentd_wrapper.go
@@ -2,11 +2,12 @@ package pilot
 
 import (
 	"fmt"
-	log "github.com/Sirupsen/logrus"
 	"os"
 	"os/exec"
 	"syscall"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 var fluentd *exec.Cmd

--- a/pilot/pilot.go
+++ b/pilot/pilot.go
@@ -27,7 +27,6 @@ aliyun.log: /var/log/hello.log[:json][;/var/log/abc/def.log[:txt]]
 
 const LABEL_SERVICE_LOGS = "aliyun.logs."
 const ENV_SERVICE_LOGS = "aliyun_logs_"
-const ENV_JSON_IN_LOG = "json_in_log"
 const FLUENTD_CONF_HOME = "/etc/fluentd"
 
 const LABEL_PROJECT = "com.docker.compose.project"

--- a/pilot/pilot_test.go
+++ b/pilot/pilot_test.go
@@ -1,11 +1,12 @@
 package pilot
 
 import (
+	"os"
+	"testing"
+
 	"github.com/docker/docker/api/types"
 	log "github.com/sirupsen/logrus"
 	check "gopkg.in/check.v1"
-	"os"
-	"testing"
 )
 
 func Test(t *testing.T) {


### PR DESCRIPTION
- `aliyun.logs.$name.jsonkey=log`: work when `aliyun.logs.$name=stdout`. can loads json from docker container log like `{"log":"{\"foo\": \"bar\"}","stream":"stdout","time":"2017-09-15T16:28:29.253264378Z"}`.